### PR TITLE
Optimize `TimeoutWatchdog` to reduce logs and add configurations

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -127,7 +127,7 @@ jobs:
           fi
 
   ondemand-oneway-generator-commuter-case:
-    name: Run historical scheduled test case
+    name: Run ondemand oneway generator commuter test case
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/src/base_simulators/ondemand/controller.py
+++ b/src/base_simulators/ondemand/controller.py
@@ -125,6 +125,8 @@ async def setup(settings: query.Setup):
         trips=trips,
         board_time=settings.board_time,
         max_delay_time=settings.max_delay_time,
+        max_calculation_seconds=settings.max_calculation_seconds,
+        max_calculation_stop_times_length=settings.max_calculation_stop_times_length,
         settings=[
             CarSetting(
                 mobility_id=mobility.mobility_id,

--- a/src/base_simulators/ondemand/jschema/query.py
+++ b/src/base_simulators/ondemand/jschema/query.py
@@ -31,7 +31,7 @@ class Setup(BaseModel):
     max_delay_time: float | None
     mobility_speed: float = 20.0 * 1000 / 60  # [m/min]
     max_calculation_seconds: int = 30
-    max_calculation_stop_times_length = 10
+    max_calculation_stop_times_length: int = 10
     mobilities: list[Mobility]
 
 

--- a/src/base_simulators/ondemand/jschema/query.py
+++ b/src/base_simulators/ondemand/jschema/query.py
@@ -30,6 +30,8 @@ class Setup(BaseModel):
     board_time: float | None
     max_delay_time: float | None
     mobility_speed: float = 20.0 * 1000 / 60  # [m/min]
+    max_calculation_seconds: int = 30
+    max_calculation_stop_times_length = 10
     mobilities: list[Mobility]
 
 

--- a/src/base_simulators/ondemand/mobility.py
+++ b/src/base_simulators/ondemand/mobility.py
@@ -48,7 +48,7 @@ class Schedule:
 
 @dataclasses.dataclass
 class TimeoutWatchDog:
-    limit_seconds: int  # [sec]
+    limit_seconds: float  # [sec]
     start_time: float = dataclasses.field(default_factory=time.perf_counter)
 
     def limit_exceeded(self):
@@ -236,7 +236,7 @@ class Car(Mobility):
     def routes_appended_new_user(
         self, user: User, timeout_seconds: int = 30, max_stop_time_length: int = 20
     ):
-        watchdog = TimeoutWatchDog(limit_seconds=timeout_seconds)
+        watchdog = TimeoutWatchDog(limit_seconds=float(timeout_seconds))
         routes = [
             Route(
                 stop_times=[
@@ -478,7 +478,7 @@ class CarManager:
         self.event_queue = event_queue
         self.board_time: timedelta = timedelta(minutes=board_time)
         self.max_delay_time: timedelta = timedelta(minutes=max_delay_time)
-        self.max_calculation_seconds = (max_calculation_seconds,)
+        self.max_calculation_seconds = max_calculation_seconds
         self.max_calculation_stop_times_length = max_calculation_stop_times_length
         self.mobilities: typing.Dict[str, Car] = {
             setting.mobility_id: Car(

--- a/src/base_simulators/ondemand/mobility.py
+++ b/src/base_simulators/ondemand/mobility.py
@@ -470,9 +470,9 @@ class CarManager:
         event_queue: EventQueue,
         board_time: float,
         max_delay_time: float,
-        max_calculation_seconds: int,
-        max_calculation_stop_times_length: int,
         settings: typing.Collection[CarSetting],
+        max_calculation_seconds: int = 30,
+        max_calculation_stop_times_length: int = 10,
     ):
         self.network = network
         self.event_queue = event_queue

--- a/src/base_simulators/ondemand/mobility.py
+++ b/src/base_simulators/ondemand/mobility.py
@@ -48,42 +48,12 @@ class Schedule:
 
 @dataclasses.dataclass
 class TimeoutWatchDog:
-    name: str
-    limit: int  # [sec]
-    interval: int = 10  # [sec]
+    limit_seconds: int  # [sec]
     start_time: float = dataclasses.field(default_factory=time.perf_counter)
-    count: int = 0
 
-    def check(self, car: Car, user: User, route: Route):
+    def limit_exceeded(self):
         elapsed = time.perf_counter() - self.start_time
-        # warning log at every interval
-        if elapsed >= self.interval + self.interval * self.count:
-            if self.count == 0:
-                logger.info(
-                    "%s: elapsed=%s[sec], car=%s, user=%s, deamnd=%s, route=%s",
-                    self.name,
-                    elapsed,
-                    car,
-                    user.user_id,
-                    user.demand_id,
-                    route.stop_times,
-                )
-            else:
-                logger.info("%s: elapsed=%s[sec]", self.name, elapsed)
-            self.count += 1
-        if elapsed < self.limit:
-            return True
-        else:
-            logger.warning(
-                "abort calculation %s: elapsed=%s[sec], car=%s, user=%s, deamnd=%s, route=%s",
-                self.name,
-                elapsed,
-                car,
-                user.user_id,
-                user.demand_id,
-                route.stop_times,
-            )
-            return False
+        return elapsed > self.limit_seconds
 
 
 class Car(Mobility):
@@ -263,10 +233,10 @@ class Car(Mobility):
 
         self.env.process(self.arrived())
 
-    def routes_appended_new_user(self, user: User):
-        watchdog = TimeoutWatchDog(
-            f"routes_appended_new_user(user={user.user_id})", limit=30, interval=5
-        )  # calculation timeout
+    def routes_appended_new_user(
+        self, user: User, timeout_seconds: int = 30, max_stop_time_length: int = 20
+    ):
+        watchdog = TimeoutWatchDog(limit_seconds=timeout_seconds)
         routes = [
             Route(
                 stop_times=[
@@ -281,11 +251,15 @@ class Car(Mobility):
         ).values():
             new_routes = []
             for route in routes:
+                if watchdog.limit_exceeded():
+                    logger.warning(
+                        f"abort calculation for appending a new user={user.user_id} to the car={self}: elapsed more than {watchdog.limit_seconds} seconds",
+                    )
+                    return []
+
                 for i, k in itertools.combinations_with_replacement(
                     range(len(route.stop_times) + 1), 2
                 ):
-                    if not watchdog.check(self, user_, route):
-                        return []
                     stop_times = [
                         StopTime(
                             stop=stop_time.stop, on=stop_time.on, off=stop_time.off
@@ -309,6 +283,11 @@ class Car(Mobility):
                     if any(
                         value > self._max_delay_time for value in Delay(self, r).values
                     ):
+                        continue
+                    if len(r.stop_times) > max_stop_time_length:
+                        logger.debug(
+                            f"skip a route for appending a new user={user.user_id} to the car={self}: exceeded max stop times length={max_stop_time_length}."
+                        )
                         continue
                     new_routes.append(r)
 
@@ -491,12 +470,16 @@ class CarManager:
         event_queue: EventQueue,
         board_time: float,
         max_delay_time: float,
+        max_calculation_seconds: int,
+        max_calculation_stop_times_length: int,
         settings: typing.Collection[CarSetting],
     ):
         self.network = network
         self.event_queue = event_queue
         self.board_time: timedelta = timedelta(minutes=board_time)
         self.max_delay_time: timedelta = timedelta(minutes=max_delay_time)
+        self.max_calculation_seconds = (max_calculation_seconds,)
+        self.max_calculation_stop_times_length = max_calculation_stop_times_length
         self.mobilities: typing.Dict[str, Car] = {
             setting.mobility_id: Car(
                 network=self.network,
@@ -525,7 +508,11 @@ class CarManager:
         for delay in sorted(
             Delay(car, route)
             for car in self.mobilities.values()
-            for route in car.routes_appended_new_user(user)
+            for route in car.routes_appended_new_user(
+                user,
+                timeout_seconds=self.max_calculation_seconds,
+                max_stop_time_length=self.max_calculation_stop_times_length,
+            )
         ):
             if all(value < self.max_delay_time for value in delay.values):
                 return delay

--- a/src/base_simulators/ondemand/simulation.py
+++ b/src/base_simulators/ondemand/simulation.py
@@ -19,10 +19,10 @@ class Simulation:
         network: Network,
         board_time: float,
         max_delay_time: float,
-        max_calculation_seconds: int,
-        max_calculation_stop_times_length: int,
         trips: dict[str, Trip],
         settings: typing.Collection[CarSetting],
+        max_calculation_seconds: int = 30,
+        max_calculation_stop_times_length: int = 10,
     ):
         self.env = Environment(start_time=start_time)
         self.event_queue = EventQueue(self.env)

--- a/src/base_simulators/ondemand/simulation.py
+++ b/src/base_simulators/ondemand/simulation.py
@@ -19,6 +19,8 @@ class Simulation:
         network: Network,
         board_time: float,
         max_delay_time: float,
+        max_calculation_seconds: int,
+        max_calculation_stop_times_length: int,
         trips: dict[str, Trip],
         settings: typing.Collection[CarSetting],
     ):
@@ -36,6 +38,8 @@ class Simulation:
             event_queue=self.event_queue,
             board_time=board_time,
             max_delay_time=max_delay_time,
+            max_calculation_seconds=max_calculation_seconds,
+            max_calculation_stop_times_length=max_calculation_stop_times_length,
             settings=settings,
         )
 


### PR DESCRIPTION
This PR addresses the excessive log output issue caused by the `TimeoutWatchdog`, which checks for excessively long computation times. The following changes have been implemented:

- Reduced the frequency of computation time checks to decrease the log output.
- Added configuration options:
  - to set the maximum computation time (`max_calculation_seconds`) and
  - to exclude overly complex routes (`max_stop_times_length`).